### PR TITLE
Coerce stream data to a Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function(input) {
 		var bufs = [];
 		var done = false;
 		stream.on("data", function(b) {
-			bufs.push(b);
+			bufs.push(Buffer.isBuffer(b) ? b : new Buffer(b));
 		});
 		stream.on("end", function() {
 			if(done) return;


### PR DESCRIPTION
When using Node v4.0.0 and `transform-loader`, the following error occurs:

```
buffer.js:219
    buf.copy(buffer, pos);
        ^

TypeError: buf.copy is not a function
    at Function.Buffer.concat (buffer.js:219:9)
    at Stream.<anonymous> (C:\Code\transform-loader\index.js:33:19)
    at emitNone (events.js:72:20)
    at Stream.emit (events.js:166:7)
    at drain (C:\Code\transform-loader\node_modules\brfs\node_modules\through\index.js:33:23)
    at Stream.stream.queue.stream.push (C:\Code\transform-loader\node_modules\brfs\node_modules\through\index.js:41:5)
    at finish (C:\Code\transform-loader\node_modules\brfs\index.js:49:12)
    at C:\Code\transform-loader\node_modules\brfs\index.js:114:38
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:380:3)
```

This is reproducible when building `test.js` in the `test` folder.

This occurs because `Buffer.concat` now expects its arguments to be buffers (or to have a `copy` method), but the data coming back from the stream is usually a `string`.

The fix is to coerce the data chunks to buffers if needed.