### PR TITLE
Add support for query option in loader config

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var loaderUtils = require("loader-utils");
 var baseRegex = "\\s*[@#]\\s*sourceMappingURL=data:[^;\n]+;base64,([^\\s]*)",
 	// Matches /* ... */ comments
 	regex1 = new RegExp("/\\*"+baseRegex+"\\s*\\*/$"),
@@ -9,10 +10,11 @@ var baseRegex = "\\s*[@#]\\s*sourceMappingURL=data:[^;\n]+;base64,([^\\s]*)",
 	regex2 = new RegExp("//"+baseRegex+".*$");
 module.exports = function(input) {
 	if(!this.query) throw new Error("Pass a module name as query to the transform-loader.");
+	var query = loaderUtils.parseQuery(this.query);
 	var callback = this.async();
 	var resource = this.resource;
 	var loaderContext = this;
-	var q = this.query.substr(1);
+	var q = Object.keys(query)[0];
 	if(/^[0-9]+$/.test(q)) {
 		next(this.options.transforms[+q]);
 	} else {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "http://github.com/webpack/transform-loader.git"
   },
+  "dependencies": {
+    "loader-utils": "^0.2.16"
+  },
   "devDependencies": {
     "brfs": "~1.0.0",
     "coffeeify": "~0.6.0"


### PR DESCRIPTION
This PR add support for parsing `query` option (via [loader-utils](https://github.com/webpack/loader-utils)) in loader configuration, so configuration can be written as:

```js
{
	test: /test\.js$/,
	loader: __dirname + "/../cacheable",
	query: {
		brfs: true
	}
}
```