### PR TITLE
Update README with -loader suffix for examples for Webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Use a browserify transforms as webpack-loader
 Pass the module name as query parameter.
 
 ``` javascript
-var x = require("!transform?brfs!./file.js");
-var x = require("!transform/cacheable?brfs!./file.js"); // cacheable version
+var x = require("!transform-loader?brfs!./file.js");
+var x = require("!transform-loader/cacheable?brfs!./file.js"); // cacheable version
 ```
 
 If you pass a number instead it will take the function from `this.options.transforms[number]`.
@@ -22,17 +22,17 @@ module.exports = {
 	module: {
 		postLoaders: [
 			{
-				loader: "transform?brfs"
+				loader: "transform-loader?brfs"
 			}
 		]
 		loaders: [
 			{
 				test: /\.coffee$/,
-				loader: "transform/cacheable?coffeeify"
+				loader: "transform-loader/cacheable?coffeeify"
 			},
 			{
 				test: /\.weirdjs$/,
-				loader: "transform?0"
+				loader: "transform-loader?0"
 			}
 		]
 	},
@@ -66,14 +66,14 @@ module.exports = {
         loaders: [
             {
                 test: /\.js$/,
-                loader: "transform?brfs"
+                loader: "transform-loader?brfs"
             }
         ]
     }
 }
 ```
 
-The loader is applied to all JS files, which can incur a performance hit with watch tasks. So you may want to use `transform/cacheable?brfs` instead. 
+The loader is applied to all JS files, which can incur a performance hit with watch tasks. So you may want to use `transform-loader/cacheable?brfs` instead. 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,45 @@ var x = require("!transform-loader/cacheable?brfs!./file.js"); // cacheable vers
 
 If you pass a number instead it will take the function from `this.options.transforms[number]`.
 
-### Example webpack config
+### Example webpack 2 config
+
+``` javascript
+module.exports = {
+  module: {
+    rules: [
+      {
+        loader: "transform-loader?brfs",
+        enforce: "post"
+      },
+			{
+        test: /\.coffee$/,
+        loader: "transform-loader/cacheable?coffeeify"
+      },
+      {
+        test: /\.weirdjs$/,
+        loader: "transform-loader?0"
+      }
+    ]
+  },
+  plugins: [
+    new webpack.LoaderOptionsPlugin({
+      options: {
+        transforms: [
+          function(file) {
+            return through(function(buf) {
+              this.queue(buf.split("").map(function(s) {
+                return String.fromCharCode(127-s.charCodeAt(0));
+              }).join(""));
+            }, function() { this.queue(null); });
+          }
+        ]
+      }
+    })
+  ]
+};
+```
+
+### Example webpack 1 config
 
 ``` javascript
 module.exports = {


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra @km-tr  